### PR TITLE
simplify socket wiring for bluz

### DIFF
--- a/hal/inc/hal_dynalib_socket.h
+++ b/hal/inc/hal_dynalib_socket.h
@@ -55,6 +55,7 @@ DYNALIB_FN(12, hal_socket, socket_handle_invalid, sock_handle_t(void))
 DYNALIB_FN(13, hal_socket, socket_join_multicast, sock_result_t(const HAL_IPAddress*, network_interface_t, void*))
 DYNALIB_FN(14, hal_socket, socket_leave_multicast, sock_result_t(const HAL_IPAddress*, network_interface_t, void*))
 DYNALIB_FN(15, hal_socket, socket_peer, sock_result_t(sock_handle_t, sock_peer_t*, void*))
+DYNALIB_FN(16, hal_socket, socket_bytes_available, sock_result_t(sock_handle_t sd))
 
 DYNALIB_END(hal_socket)
 

--- a/user/applications/tcpclient/tcpclient.cpp
+++ b/user/applications/tcpclient/tcpclient.cpp
@@ -1,46 +1,51 @@
 #include "application.h"
 
-Serial1DebugOutput debugOutput(38400); // default is 9600 and log everything
-
 TCPClient client;
-IPAddress ip = { 10, 0, 1, 112 };
+IPAddress ip = { 10, 1, 10, 175 };
+Serial1DebugOutput debugOutput(38400);
+
+int blink(String pin) {
+    digitalWrite(D7, HIGH);
+    delay(200);
+    digitalWrite(D7, LOW);
+}
     
 void setup()
 {
+    pinMode(D7, OUTPUT);
+    Serial1.begin(38400);
+    Serial1.println("Starting!");
+    Particle.function("blink", blink);
 }
 
 void loop()
 {
   static bool oneshot = true;
-  static uint32_t t = millis(); 
+  static bool twoshot = true;
   if (oneshot && Particle.connected())
   {
-    Particle.publish("TCPClient Test", "ONLINE");
+    Serial1.println("TCPClient Test - ONLINE");
     oneshot=false;
-    t = millis();
     if (client.connect(ip, 22))
     {
-      Particle.publish("TCP connect", "success!");
+      Serial1.println("TCP connect - success!");
     }
     else
     {
-      Particle.publish("TCP connect", "failed :-(");
+      Serial1.println("TCP connect - failed :-(");
     }
   }
-  if (!oneshot && millis() > (t + 5000)) { 
-    t = millis(); Particle.publish("PING"); 
-/*
-    String s = "";
-    int bytes;
-    while ( (bytes = client.available()) ) s += client.read();
-    if (s.length()) { 
-      char sbuf[1024]; 
-      s.toCharArray(sbuf, sizeof(sbuf));
-      DEBUG("TCP_DATA: %s", sbuf); 
-      s = "";
+    if (client.available() > 0 && twoshot) {
+        twoshot = false;
+        Serial1.print("TCP has data of: ");
+        Serial1.print(client.available());
+        Serial1.println("");
+        while (client.available() > 0) {
+            char inByte = client.read();
+            Serial1.print(inByte);
+        }
+        Serial1.println(" bytes!");
     }
-*/
-  }
 }
 
 

--- a/wiring/inc/bluz_wiring_tcpclient.h
+++ b/wiring/inc/bluz_wiring_tcpclient.h
@@ -51,7 +51,6 @@ public:
 	virtual int read(uint8_t *buffer, size_t size);
 	virtual int peek();
 	virtual void flush();
-        void flush_buffer();
 	virtual void stop();
 	virtual uint8_t connected();
 	virtual operator bool();
@@ -68,11 +67,7 @@ protected:
 private:
 	static uint16_t _srcport;
 	sock_handle_t _sock;
-	uint8_t _buffer[TCPCLIENT_BUF_MAX_SIZE];
-	uint16_t _offset;
-	uint16_t _total;
-        IPAddress _remoteIP;
-	inline int bufferCount();
+    IPAddress _remoteIP;
 
 };
 

--- a/wiring/src/bluz_wiring_tcpclient.cpp
+++ b/wiring/src/bluz_wiring_tcpclient.cpp
@@ -50,135 +50,98 @@ TCPClient::TCPClient() : TCPClient(socket_handle_invalid())
 
 TCPClient::TCPClient(sock_handle_t sock) : _sock(sock)
 {
-  flush_buffer();
 }
 
 int TCPClient::connect(const char* host, uint16_t port, network_interface_t nif)
 {
     stop();
-      int rv = 0;
-      if(HAL_BLE_GET_STATE() == BLUETOOTH_LE_CONNECTED)
-      {
+    int rv = 0;
+    if(HAL_BLE_GET_STATE() == BLUETOOTH_LE_CONNECTED)
+    {
         IPAddress ip_addr;
 
         if((rv = X_inet_gethostbyname(host, strlen(host), ip_addr, nif, NULL)) == 0)
         {
-                return connect(ip_addr, port, nif);
+            return connect(ip_addr, port, nif);
         }
-        else
+        else {
             DEBUG("unable to get IP for hostname");
-      }
-      return rv;
+        }
+  }
+  return rv;
 }
 
 int TCPClient::connect(IPAddress ip, uint16_t port, network_interface_t nif)
 {
     stop();
-        int connected = 0;
-        if(HAL_BLE_GET_STATE() == BLUETOOTH_LE_CONNECTED)
+    int connected = 0;
+    if(HAL_BLE_GET_STATE() == BLUETOOTH_LE_CONNECTED)
+    {
+      sockaddr_t tSocketAddr;
+      _sock = socket_create(AF_INET, SOCK_STREAM, IPPROTO_TCP, port, nif);
+      DEBUG("socket=%d",_sock);
+
+      if (socket_handle_valid(_sock))
+      {
+        tSocketAddr.sa_family = AF_INET;
+
+        tSocketAddr.sa_data[0] = (port & 0xFF00) >> 8;
+        tSocketAddr.sa_data[1] = (port & 0x00FF);
+
+        tSocketAddr.sa_data[2] = ip[0];        // Todo IPv6
+        tSocketAddr.sa_data[3] = ip[1];
+        tSocketAddr.sa_data[4] = ip[2];
+        tSocketAddr.sa_data[5] = ip[3];
+
+        // uint32_t ot = HAL_NET_SetNetWatchDog(S2M(MAX_SEC_WAIT_CONNECT));
+        DEBUG("_sock %d connect",_sock);
+        connected = !(socket_connect(_sock, &tSocketAddr, sizeof(tSocketAddr))); // socket_connect() returns 0 on success
+        DEBUG("_sock %d connected=%d",_sock, connected);
+        //HAL_NET_SetNetWatchDog(ot);
+        _remoteIP = ip;
+        if(!connected)
         {
-          sockaddr_t tSocketAddr;
-          _sock = socket_create(AF_INET, SOCK_STREAM, IPPROTO_TCP, port, nif);
-          DEBUG("socket=%d",_sock);
-
-          if (socket_handle_valid(_sock))
-          {
-            flush_buffer();
-
-            tSocketAddr.sa_family = AF_INET;
-
-            tSocketAddr.sa_data[0] = (port & 0xFF00) >> 8;
-            tSocketAddr.sa_data[1] = (port & 0x00FF);
-
-            tSocketAddr.sa_data[2] = ip[0];        // Todo IPv6
-            tSocketAddr.sa_data[3] = ip[1];
-            tSocketAddr.sa_data[4] = ip[2];
-            tSocketAddr.sa_data[5] = ip[3];
-
-            // uint32_t ot = HAL_NET_SetNetWatchDog(S2M(MAX_SEC_WAIT_CONNECT));
-            DEBUG("_sock %d connect",_sock);
-            connected = !(socket_connect(_sock, &tSocketAddr, sizeof(tSocketAddr))); // socket_connect() returns 0 on success
-            DEBUG("_sock %d connected=%d",_sock, connected);
-            //HAL_NET_SetNetWatchDog(ot);
-            _remoteIP = ip;
-            if(!connected)
-            {
-                stop();
-            }
-          }
+            stop();
         }
-        return connected;
+      }
+    }
+    return connected;
 }
 
 size_t TCPClient::write(uint8_t b)
 {
-        return write(&b, 1);
+    return write(&b, 1);
 }
 
 size_t TCPClient::write(const uint8_t *buffer, size_t size)
 {
-        return status() ? socket_send(_sock, buffer, size) : -1;
-}
-
-int TCPClient::bufferCount()
-{
-  return _total - _offset;
+    return status() ? socket_send(_sock, buffer, size) : -1;
 }
 
 int TCPClient::available()
 {
-    int avail = 0;
-
-    // At EOB => Flush it
-    if (_total && (_offset == _total))
-    {
-        flush_buffer();
-    }
-
-    if(HAL_BLE_GET_STATE() == BLUETOOTH_LE_CONNECTED && isOpen(_sock))
-    {
-        // Have room
-        if ( _total < arraySize(_buffer))
-        {
-            int ret = socket_receive(_sock, _buffer + _total , arraySize(_buffer)-_total, 0);
-            if (ret > 0)
-            {
-                DEBUG("recv(=%d)",ret);
-                if (_total == 0) _offset = 0;
-                _total += ret;
-            }
-        } // Have Space
-    } // WiFi.ready() && isOpen(_sock)
-    avail = bufferCount();
-    return avail;
+    return socket_bytes_available(_sock);
 }
 
 int TCPClient::read()
 {
-  return (bufferCount() || available()) ? _buffer[_offset++] : -1;
+    uint8_t buf[1];
+    if (read(buf, 1) == 1) {
+        return buf[0];
+    } else {
+        return -1;
+    }
 }
 
 int TCPClient::read(uint8_t *buffer, size_t size)
 {
-        int read = -1;
-        if (bufferCount() || available())
-        {
-          read = (size > (size_t) bufferCount()) ? bufferCount() : size;
-          memcpy(buffer, &_buffer[_offset], read);
-          _offset += read;
-        }
-        return read;
+    return socket_receive(_sock, buffer , size, 0);
 }
 
 int TCPClient::peek()
 {
-  return  (bufferCount() || available()) ? _buffer[_offset] : -1;
-}
-
-void TCPClient::flush_buffer()
-{
-  _offset = 0;
-  _total = 0;
+    //TO DO: Implement this
+    return  -1;
 }
 
 void TCPClient::flush()
@@ -196,23 +159,11 @@ void TCPClient::stop()
       socket_close(_sock);
   _sock = socket_handle_invalid();
   _remoteIP.clear();
-  flush_buffer();
 }
 
 uint8_t TCPClient::connected()
 {
-  // Wlan up, open and not in CLOSE_WAIT or data still in the local buffer
-  bool rv = (status() || bufferCount());
-  // no data in the local buffer, Socket open but my be in CLOSE_WAIT yet the CC3000 may have data in its buffer
-  if(!rv && isOpen(_sock) && (SOCKET_STATUS_INACTIVE == socket_active_status(_sock)))
-    {
-      rv = available(); // Try CC3000
-      if (!rv) {        // No more Data and CLOSE_WAIT
-          DEBUG("caling Stop No more Data and in CLOSE_WAIT");
-          stop();       // Close our side
-      }
-  }
-  return rv;
+    return socket_active_status(_sock) == SOCKET_STATUS_ACTIVE;
 }
 
 uint8_t TCPClient::status()


### PR DESCRIPTION
I have a theory on why you may be seeing the issue. If you have a chance in the next few days, could you possibly try this PR? It simplifies the bluz tcp wiring library as most of the functionality is already taken care of, so I am doing more straight through calls. The key to my theory is that we are eliminating a 1024 byte buffer that is allocated in the bluz wiring class.

Let me know if you have a chance. Thanks

---

Doneness:

- [ ] Contributor has signed CLA
- [ ] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)
